### PR TITLE
Use ink-color-pipe instead of built-in color component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -924,9 +924,9 @@
       }
     },
     "ink-color-pipe": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ink-color-pipe/-/ink-color-pipe-0.1.0.tgz",
-      "integrity": "sha512-g/BAIxdBiCE+sop/7uPpnVLrLu+UuWonfWhllhD7W9dGpn7IhjBIVavVF61a5AnmRc8vhsoRuTezor+3tZfJWA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ink-color-pipe/-/ink-color-pipe-0.2.0.tgz",
+      "integrity": "sha512-MwNuaPPd7XrQYD43aMjhKn3iX+sDLVZLmDLyy1mRNSk7X0gXBZzu0RLBWmtp6aHFV9VhW6aGp0Hi4fnPcowOpg==",
       "requires": {
         "chalk-pipe": "^2.0.0",
         "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "ink": "^2.1.0",
-    "ink-color-pipe": "^0.1.0",
+    "ink-color-pipe": "^0.2.0",
     "ink-select-input": "^3.1.0",
     "ink-text-input": "^3.1.0",
     "mkdirp": "^0.5.1",

--- a/src/ui/containers/game-list.tsx
+++ b/src/ui/containers/game-list.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ColorPipe } from 'ink-color-pipe';
+import ColorPipe from 'ink-color-pipe';
 import { createContainer, ContainerConfig } from '../../utils/create-container';
 import { State } from '../store/model';
 import { FlexTable, StateProps, CellProps } from '../components/ink-flex-table';

--- a/src/ui/containers/game-list.tsx
+++ b/src/ui/containers/game-list.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Color } from 'ink';
+import { ColorPipe } from 'ink-color-pipe';
 import { createContainer, ContainerConfig } from '../../utils/create-container';
 import { State } from '../store/model';
 import { FlexTable, StateProps, CellProps } from '../components/ink-flex-table';
@@ -15,16 +15,21 @@ function mapStateToProps(state: State): StateProps<GameListInfo> {
   const { gameList } = state.ui;
 
   function Cell({ children, row }: CellProps) {
-    if (row === gameList.selected && row === gameList.focused) {
-      return <Color yellowBright>{children}</Color>;
+    let color = 'grey';
+
+    switch (true) {
+      case row === gameList.selected && row === gameList.focused:
+        color = 'yellowBright';
+        break;
+      case row === gameList.selected:
+        color = 'yellow';
+        break;
+      case row === gameList.focused:
+        color = 'white';
+        break;
     }
-    if (row === gameList.selected) {
-      return <Color yellow>{children}</Color>;
-    }
-    if (row === gameList.focused) {
-      return <Color white>{children}</Color>;
-    }
-    return <Color gray>{children}</Color>;
+
+    return <ColorPipe styles={color}>{children}</ColorPipe>;
   }
 
   return {


### PR DESCRIPTION
By using `<ColorPipe />`, we no longer need to write `return <Color ...>...</Color>` so many times. 

But we don't have to use `<ColorPipe />` elsewhere, so I only modified the code in this file.